### PR TITLE
Update NDK to r26b

### DIFF
--- a/.github/workflows/extension-build.yaml
+++ b/.github/workflows/extension-build.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NDK_VER: 21.4.7075529
+  NDK_VER: 26.1.10909125
 
 jobs:
   build:

--- a/.github/workflows/extension-publish.yaml
+++ b/.github/workflows/extension-publish.yaml
@@ -8,7 +8,7 @@ on:
       - master
 
 env:
-  NDK_VER: 21.4.7075529
+  NDK_VER: 26.1.10909125
 
 jobs:
   publish:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,13 @@ allprojects {
         google()
     }
 
-    // Force specific NDK version
+    // Set minSdk to 21 and force a specific NDK version
     afterEvaluate {
         val android = extensions.findByType(LibraryExtension::class.java)
-        android?.ndkVersion = "21.4.7075529"
+        if (android != null) {
+            android.defaultConfig.minSdk = 21
+            android.ndkVersion = "26.1.10909125"
+        }
     }
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Ensure NDK is available
-export ANDROID_NDK_PATH=$ANDROID_HOME/ndk/21.4.7075529
+export ANDROID_NDK_PATH=$ANDROID_HOME/ndk/26.1.10909125
 
 [[ -z "$ANDROID_NDK_PATH" ]] && echo "No NDK found, quitting…" && exit 1
 
@@ -16,4 +16,4 @@ ln -sf "${FFMPEG_PATH}" "${FFMPEG_MOD_PATH}/jni/ffmpeg"
 
 # Start build
 cd "${FFMPEG_MOD_PATH}/jni"
-./build_ffmpeg.sh "${FFMPEG_MOD_PATH}" "${ANDROID_NDK_PATH}" "linux-x86_64" 16 "${ENABLED_DECODERS[@]}"
+./build_ffmpeg.sh "${FFMPEG_MOD_PATH}" "${ANDROID_NDK_PATH}" "linux-x86_64" 21 "${ENABLED_DECODERS[@]}"

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 # Ensure NDK is available
 export ANDROID_NDK_PATH=$ANDROID_HOME/ndk/26.1.10909125
 
-[[ -z "$ANDROID_NDK_PATH" ]] && echo "No NDK found, quitting…" && exit 1
+[[ ! -d "$ANDROID_NDK_PATH" ]] && echo "No NDK found, quitting…" && exit 1
 
 # Setup environment
 export ANDROIDX_MEDIA_ROOT="${PWD}/media"


### PR DESCRIPTION
The raise in minSdk/ABI was necessary because NDK r26b doesn't support anything below 21. Since none of our apps support it either, this shouldn't be an issue.

Please rebase when merging.