### PR TITLE
Fix snapshot version string

### DIFF
--- a/buildSrc/src/main/kotlin/Properties.kt
+++ b/buildSrc/src/main/kotlin/Properties.kt
@@ -12,7 +12,7 @@ fun Project.getProperty(name: String): String? {
     return value
 }
 
-const val SNAPSHOT_VERSION = "SNAPSHOT"
+const val SNAPSHOT_VERSION = "latest-SNAPSHOT"
 
 /**
  * Helper function to create the library version using the `jellyfin.version` property.


### PR DESCRIPTION
Maven Central only allows "snapshot" as a suffix, so we now name snapshots "latest-SNAPSHOT". This follows the behavior in the Jellyfin Kotlin SDK.